### PR TITLE
Add speaker recognition with embeddings

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,5 @@ python manage.py runserver
 ```
 
 The application will be accessible at `http://127.0.0.1:8000/`.
+### Speaker Recognition
+The system stores voice embeddings to remember speaker names across recordings.

--- a/api/models.py
+++ b/api/models.py
@@ -105,6 +105,16 @@ class SessionUser(models.Model):
 
     def __str__(self):
         return f"{self.user.username} in {self.session.name}"
+
+class SpeakerProfile(models.Model):
+    """Stores a speaker embedding with an associated human readable name."""
+    name = models.CharField(max_length=100, unique=True)
+    embedding = models.JSONField()
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    def __str__(self):
+        return self.name
     
 class FeedbackReview(models.Model):
     reviewer = models.ForeignKey(UserProfile, on_delete=models.CASCADE, related_name='feedback_reviews')


### PR DESCRIPTION
## Summary
- add `SpeakerProfile` model to store voice embeddings with a name
- compute and aggregate speaker embeddings during transcription
- automatically match or create speaker profiles when processing audio
- update README with speaker recognition note

## Testing
- `pytest -q` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_b_685cdbb198fc832f902cfe8e3bfe824b