### PR TITLE
Add speaker identification feature

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -168,3 +168,20 @@ class AuditLog(models.Model):
 
     def __str__(self):
         return f"{self.action} by {self.user.username if self.user else 'Unknown'} at {self.timestamp}"
+
+class SpeakerProfile(models.Model):
+    name = models.CharField(max_length=100)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    def __str__(self):
+        return self.name
+
+class SpeakerEmbedding(models.Model):
+    vector = models.JSONField()
+    speaker = models.ForeignKey(SpeakerProfile, on_delete=models.SET_NULL, null=True, blank=True, related_name="embeddings")
+    audio_file = models.ForeignKey(AudioFile, on_delete=models.CASCADE, related_name="speaker_embeddings")
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    def __str__(self):
+        return f"Embedding {self.id} for {self.speaker.name if self.speaker else 'Unknown'}"

--- a/api/permissions.py
+++ b/api/permissions.py
@@ -55,6 +55,8 @@ class RoleBasedPermission(permissions.BasePermission):
                 'sessionstatusupdateview': ['patch'], 
                 'adminuserlistview': ['get'],
                 'userprofiledetailsview': ['get'],
+                'speakerprofilelistcreateview': ['get', 'post'],
+                'speakerembeddingassignview': ['post'],
             },
             'reviewer': {
                 'soplistview': ['get'],
@@ -71,6 +73,7 @@ class RoleBasedPermission(permissions.BasePermission):
                 'auditlogview': ['get'],
                 'usersettingsview': ['get', 'patch'],
                 'userprofiledetailsview': ['get'],
+                'speakerprofilelistcreateview': ['get'],
             }
         }
 

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -347,3 +347,20 @@ class FeedbackReviewSerializer(serializers.ModelSerializer):
         instance.resolved_flag = validated_data.get('resolved_flag', instance.resolved_flag)
         instance.save()
         return instance
+
+
+class SpeakerProfileSerializer(serializers.ModelSerializer):
+    embedding_count = serializers.IntegerField(source='embeddings.count', read_only=True)
+
+    class Meta:
+        model = SpeakerProfile
+        fields = ['id', 'name', 'embedding_count', 'created_at', 'updated_at']
+
+
+class SpeakerEmbeddingSerializer(serializers.ModelSerializer):
+    speaker = SpeakerProfileSerializer(read_only=True)
+    speaker_id = serializers.IntegerField(write_only=True, required=False)
+
+    class Meta:
+        model = SpeakerEmbedding
+        fields = ['id', 'vector', 'speaker', 'speaker_id', 'audio_file', 'created_at']

--- a/api/urls.py
+++ b/api/urls.py
@@ -4,9 +4,10 @@ from .views import (ProcessAudioView, FeedbackView, FeedbackListView, FeedbackDe
                     GetAudioRecordsView, AudioFileDetailView, ReAnalyzeAudioView,
                     SOPCreateView, SOPListView, SOPDetailView, 
                     SessionCreateView, SessionListView, SessionDetailView, 
-                    SessionReviewView, SessionStatusUpdateView, 
+                    SessionReviewView, SessionStatusUpdateView,
                     AdminUserListView, AdminUserDetailView, AdminDashboardSummaryView, # Added AdminDashboardSummaryView
-                    UserSettingsView, SystemSettingsView, AuditLogView,UserProfileDetailsView)
+                    UserSettingsView, SystemSettingsView, AuditLogView,UserProfileDetailsView,
+                    SpeakerProfileListCreateView, SpeakerEmbeddingAssignView)
 from .authentication import RegisterView, LoginViewAPI, LogoutViewAPI
 
 urlpatterns = [
@@ -50,4 +51,8 @@ urlpatterns = [
     path('admin/users/<str:token>/', AdminUserListView.as_view(), name='admin-user-list'),
     path('admin/user/<int:user_id>/<str:token>/', AdminUserDetailView.as_view(), name='admin-user-detail'),
     path('admin/dashboard-summary/<str:token>/', AdminDashboardSummaryView.as_view(), name='admin-dashboard-summary'), # New dashboard summary URL
+
+    # Speaker management
+    path('speakers/<str:token>/', SpeakerProfileListCreateView.as_view(), name='speaker-profiles'),
+    path('speakers/assign/<int:embedding_id>/<str:token>/', SpeakerEmbeddingAssignView.as_view(), name='speaker-assign'),
 ]


### PR DESCRIPTION
## Summary
- add `SpeakerProfile` and `SpeakerEmbedding` models to store speaker names and vectors
- expose serializers for new models
- support auto speaker matching and embedding storage in `ProcessAudioView`
- add API endpoints for listing and assigning speaker profiles
- update permissions and tests for new functionality

## Testing
- `python -m pytest -q` *(fails: no tests discovered)*
- `python manage.py test -v 0` *(fails: couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_b_685d3519d9c0832f95147328c11be1f7