### PR TITLE
Add speaker rename capability

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -8,6 +8,7 @@ from .views import (ProcessAudioView, FeedbackView, FeedbackListView, FeedbackDe
                     AdminUserListView, AdminUserDetailView, AdminDashboardSummaryView, # Added AdminDashboardSummaryView
                     UserSettingsView, SystemSettingsView, AuditLogView,UserProfileDetailsView,
                     SpeakerProfileUpdateView, SpeakerProfileListView)
+from .views import AudioSpeakerRenameView
 from .authentication import RegisterView, LoginViewAPI, LogoutViewAPI
 
 urlpatterns = [
@@ -53,4 +54,5 @@ urlpatterns = [
     path('admin/dashboard-summary/<str:token>/', AdminDashboardSummaryView.as_view(), name='admin-dashboard-summary'), # New dashboard summary URL
     path('speakers/<str:token>/', SpeakerProfileListView.as_view(), name='speaker-list'),
     path('speaker/<int:profile_id>/<str:token>/', SpeakerProfileUpdateView.as_view(), name='speaker-update'),
+    path('audio-file/<int:audio_id>/rename-speakers/<str:token>/', AudioSpeakerRenameView.as_view(), name='audio-speaker-rename'),
 ]


### PR DESCRIPTION
## Summary
- support custom speaker labels in stored transcriptions
- API endpoint `AudioSpeakerRenameView` allows renaming speakers for an audio file
- helper `apply_custom_speaker_names` updates transcriptions and speaker profiles
- tests cover renaming workflow

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_b_6863ce60eeb0832face06bb713162ad8