### PR TITLE
Add speaker renaming support

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,24 @@ Detected speaker embeddings are matched to stored profiles so the same
 real-world speaker receives a consistent label across recordings. These
 profiles ensure that a familiar voice is labelled consistently across
 uploads.
+
+## Renaming Default Speakers
+
+Existing transcriptions may contain generic labels such as `Speaker_1` or
+`Speaker_2`. Use the `audio-file/<id>/rename-speakers/` endpoint to replace
+these labels with real names and update the underlying speaker profiles. Send a
+JSON object mapping the old label to the new name. The payload can include the
+mapping directly or under the `speaker_mapping`/`speaker_names` key:
+
+```bash
+PUT /api/audio-file/42/rename-speakers/<token>/
+{
+  "speaker_mapping": {
+    "Speaker_1": "Bob",
+    "Speaker_2": "Alice"
+  }
+}
+```
+The service calculates the average embedding for each labelled speaker,
+updates or creates a corresponding `SpeakerProfile`, storing the averaged
+speaker vector, and rewrites the transcription with the new names.

--- a/api/urls.py
+++ b/api/urls.py
@@ -7,7 +7,7 @@ from .views import (ProcessAudioView, FeedbackView, FeedbackListView, FeedbackDe
                     SessionReviewView, SessionStatusUpdateView, 
                     AdminUserListView, AdminUserDetailView, AdminDashboardSummaryView, # Added AdminDashboardSummaryView
                     UserSettingsView, SystemSettingsView, AuditLogView,UserProfileDetailsView,
-                    SpeakerProfileUpdateView, SpeakerProfileListView)
+                    SpeakerProfileUpdateView, SpeakerProfileListView, AudioFileSpeakerUpdateView)
 from .authentication import RegisterView, LoginViewAPI, LogoutViewAPI
 
 urlpatterns = [
@@ -53,4 +53,6 @@ urlpatterns = [
     path('admin/dashboard-summary/<str:token>/', AdminDashboardSummaryView.as_view(), name='admin-dashboard-summary'), # New dashboard summary URL
     path('speakers/<str:token>/', SpeakerProfileListView.as_view(), name='speaker-list'),
     path('speaker/<int:profile_id>/<str:token>/', SpeakerProfileUpdateView.as_view(), name='speaker-update'),
+    path('audio-file/<int:audio_id>/rename-speakers/<str:token>/', AudioFileSpeakerUpdateView.as_view(),
+         name='audiofile-rename-speakers'),
 ]


### PR DESCRIPTION
## Summary
- implement `AudioFileSpeakerUpdateView` to rename speaker labels in an audio file
- wire new view into API routes
- update README with usage information for renaming speakers
- compute averaged speaker embeddings when renaming

## Testing
- `python -m pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_6864bc9f4eb0832fbc5eecc01bb36bac