### PR TITLE
Add procedure validation endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,22 @@ Detected speaker embeddings are matched to stored profiles so the same
 real-world speaker receives a consistent label across recordings. These
 profiles ensure that a familiar voice is labelled consistently across
 uploads.
+
+## Procedure Validation API
+
+The `validate-procedure/` endpoint allows you to upload an audio file along with
+the original procedure document (PDF, DOCX or plain text). After transcription,
+the API extracts the instructions, compares the conversation with each step and
+highlights any missed instructions.
+
+Example usage:
+
+```bash
+curl -X POST -F "file=@meeting.wav" \
+     -F "procedure_document=@procedure.pdf" \
+     http://localhost:8000/api/validate-procedure/<token>/
+```
+
+The response includes `procedure_comparison.results` for each step as well as
+`highlighted_document_markdown` and `highlighted_document_html` showing missed
+instructions in **bold** or in red.

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -183,6 +183,12 @@ class ProcessAudioViewSerializer(serializers.Serializer):
     keywords = serializers.CharField(required=False, allow_blank=True)
     session_user_ids = SessionUserIdsSerializer(required=False)
 
+class ProcedureValidationSerializer(serializers.Serializer):
+    """Serializer for validating a procedure document against an audio file."""
+    file = serializers.FileField(required=True)
+    procedure_document = serializers.FileField(required=True)
+    procedure_text = serializers.CharField(required=False, allow_blank=True, help_text="Optional plain text instructions if already extracted")
+
     def validate_session_user_ids(self, value):
         # If the nested object is provided as a string, attempt to parse it
         if isinstance(value, str):

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,17 +1,39 @@
 from django.urls import path
-from .views import (ProcessAudioView, FeedbackView, FeedbackListView, FeedbackDetailView, 
-                    FeedbackReviewListView, FeedbackReviewDetailView, 
-                    GetAudioRecordsView, AudioFileDetailView, ReAnalyzeAudioView,
-                    SOPCreateView, SOPListView, SOPDetailView, 
-                    SessionCreateView, SessionListView, SessionDetailView, 
-                    SessionReviewView, SessionStatusUpdateView, 
-                    AdminUserListView, AdminUserDetailView, AdminDashboardSummaryView, # Added AdminDashboardSummaryView
-                    UserSettingsView, SystemSettingsView, AuditLogView,UserProfileDetailsView,
-                    SpeakerProfileUpdateView, SpeakerProfileListView, GenerateSummaryFromAudioID)
+from .views import (
+    ProcessAudioView,
+    ProcedureValidationView,
+    FeedbackView,
+    FeedbackListView,
+    FeedbackDetailView,
+    FeedbackReviewListView,
+    FeedbackReviewDetailView,
+    GetAudioRecordsView,
+    AudioFileDetailView,
+    ReAnalyzeAudioView,
+    SOPCreateView,
+    SOPListView,
+    SOPDetailView,
+    SessionCreateView,
+    SessionListView,
+    SessionDetailView,
+    SessionReviewView,
+    SessionStatusUpdateView,
+    AdminUserListView,
+    AdminUserDetailView,
+    AdminDashboardSummaryView,  # Added AdminDashboardSummaryView
+    UserSettingsView,
+    SystemSettingsView,
+    AuditLogView,
+    UserProfileDetailsView,
+    SpeakerProfileUpdateView,
+    SpeakerProfileListView,
+    GenerateSummaryFromAudioID,
+)
 from .authentication import RegisterView, LoginViewAPI, LogoutViewAPI
 
 urlpatterns = [
     path('process-audio/<str:token>/', ProcessAudioView.as_view(), name='process-audio'),
+    path('validate-procedure/<str:token>/', ProcedureValidationView.as_view(), name='validate-procedure'),
     
     # Feedback URLs
     path('submit-feedback/<str:token>/', FeedbackView.as_view(), name='submit-feedback'), # Existing POST for create


### PR DESCRIPTION
## Summary
- update procedure validation docs with example document upload
- allow ProcedureValidationSerializer to accept procedure document files
- parse procedure documents in `extract_text_from_document`
- color highlight missed instructions in HTML and markdown
- include extracted text in validation response and tests

## Testing
- `pytest -q`
- `python manage.py test` *(fails: Django not installed)*

------
https://chatgpt.com/codex/tasks/task_b_686d4d4f74dc832fafa98c6fa125602d