### PR TITLE
Add partial-start procedure comparison

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -388,7 +388,8 @@ class ProcedureValidationView(CreateAPIView):
             logger.error(f"Transcription failed: {str(e)}")
             return Response({"error": "Transcription failed"}, status=status.HTTP_400_BAD_REQUEST)
 
-        comparison = compare_procedure_with_transcription(procedure_text, transcription_text)
+        start_index = find_procedure_start_index(procedure_text, transcription_text)
+        comparison = compare_procedure_from_index(procedure_text, transcription_text, start_index)
 
         return Response(
             {
@@ -396,6 +397,7 @@ class ProcedureValidationView(CreateAPIView):
                 "transcription_text": transcription_text,
                 "procedure_text": procedure_text,
                 "procedure_comparison": comparison,
+                "start_step_index": start_index,
             },
             status=status.HTTP_200_OK,
         )


### PR DESCRIPTION
## Summary
- detect where an audio file begins within a procedure
- compare transcription to procedure starting from that step
- return start index and highlight missed steps
- adjust tests for new functionality

## Testing
- `pip install -q -r requirements.txt` *(fails: Could not find vosk)*
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_b_686e5f876f24832fae8c2ad6217b1ae3