### PR TITLE
Implement PeerCheckValidationView endpoint

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -241,6 +241,13 @@ class ProcessAudioViewSerializer(serializers.Serializer):
     #                 raise serializers.ValidationError("Invalid session_user_ids format. Must be a list of integers.")
     #     return value
 
+
+class PeerCheckValidationSerializer(serializers.Serializer):
+    """Serializer for PeerCheck validation endpoint."""
+    audio_file = serializers.FileField()
+    document_file = serializers.FileField()
+
+
 class SessionSerializer(serializers.ModelSerializer):
     audio_files = AudioFileSerializer(many=True, read_only=True)
     # sop = SOPSerializer(read_only=True) # Keep original for GET display

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,13 +1,34 @@
 from django.urls import path
-from .views import (ProcessAudioView, FeedbackView, FeedbackListView, FeedbackDetailView, 
-                    FeedbackReviewListView, FeedbackReviewDetailView, 
-                    GetAudioRecordsView, AudioFileDetailView, ReAnalyzeAudioView,
-                    SOPCreateView, SOPListView, SOPDetailView, 
-                    SessionCreateView, SessionListView, SessionDetailView, 
-                    SessionReviewView, SessionStatusUpdateView, 
-                    AdminUserListView, AdminUserDetailView, AdminDashboardSummaryView, # Added AdminDashboardSummaryView
-                    UserSettingsView, SystemSettingsView, AuditLogView,UserProfileDetailsView,
-                    SpeakerProfileUpdateView, SpeakerProfileListView, GenerateSummaryFromAudioID)
+from .views import (
+    ProcessAudioView,
+    FeedbackView,
+    FeedbackListView,
+    FeedbackDetailView,
+    FeedbackReviewListView,
+    FeedbackReviewDetailView,
+    GetAudioRecordsView,
+    AudioFileDetailView,
+    ReAnalyzeAudioView,
+    SOPCreateView,
+    SOPListView,
+    SOPDetailView,
+    SessionCreateView,
+    SessionListView,
+    SessionDetailView,
+    SessionReviewView,
+    SessionStatusUpdateView,
+    AdminUserListView,
+    AdminUserDetailView,
+    AdminDashboardSummaryView,  # Added AdminDashboardSummaryView
+    UserSettingsView,
+    SystemSettingsView,
+    AuditLogView,
+    UserProfileDetailsView,
+    SpeakerProfileUpdateView,
+    SpeakerProfileListView,
+    GenerateSummaryFromAudioID,
+    PeerCheckValidationView,
+)
 from .authentication import RegisterView, LoginViewAPI, LogoutViewAPI
 
 urlpatterns = [
@@ -55,4 +76,5 @@ urlpatterns = [
     path('speaker/<int:profile_id>/<str:token>/', SpeakerProfileUpdateView.as_view(), name='speaker-update'),
 
     path('audio/<str:token>/<int:audio_id>/generate-summary/', GenerateSummaryFromAudioID.as_view(), name='generate-summary-from-audio'),
+    path('peercheck/validate/', PeerCheckValidationView.as_view(), name='peercheck-validation'),
 ]


### PR DESCRIPTION
## Summary
- add `PeerCheckValidationSerializer`
- extend utils with NeMo transcription, document extraction and LLaMA call helpers
- implement `PeerCheckValidationView` view
- expose new API route `/api/peercheck/validate/`

## Testing
- `python manage.py test` *(fails: Could not import Django)*

------
https://chatgpt.com/codex/tasks/task_b_6871f1e4fb8c832f806132fc2c6788e5