### PR TITLE
Refactor audio processing with async pipeline

### DIFF
--- a/api/pipeline.py
+++ b/api/pipeline.py
@@ -1,0 +1,70 @@
+"""Async processing pipeline for PeerCheck."""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import List, Tuple, Optional
+
+import requests
+
+from .new_enhanced import (
+    EnhancedAudioProcessor,
+    LLMContentValidator,
+    SpeakerTimelineGenerator,
+    SpeakerSegment,
+    StepMatch,
+    _generate_enhanced_summary,
+)
+
+@dataclass
+class TranscriptMetadata:
+    """Container for enriched transcript data."""
+
+    transcript: str
+    segments: List[SpeakerSegment]
+    matches: List[StepMatch]
+    coverage: float
+    summary: str
+    timeline: bytes
+
+
+class PeerCheckPipeline:
+    """High level pipeline orchestrating the PeerCheck workflow."""
+
+    def __init__(self, hf_token: Optional[str] = None) -> None:
+        self.audio_processor = EnhancedAudioProcessor(hf_token)
+        self.validator = LLMContentValidator()
+        self.validator.load_models()
+        self.timeline_generator = SpeakerTimelineGenerator()
+
+    async def process(
+        self,
+        audio_url: str,
+        steps: List[Tuple[str, str]],
+        procedure_text: str,
+    ) -> TranscriptMetadata:
+        loop = asyncio.get_running_loop()
+        response = await asyncio.to_thread(requests.get, audio_url, stream=True)
+        response.raise_for_status()
+
+        transcript, segments = await asyncio.to_thread(
+            self.audio_processor.transcribe_with_speaker_diarization, response
+        )
+
+        matches = await asyncio.to_thread(
+            self.validator.advanced_step_matching, steps, segments
+        )
+        coverage = self.validator._calculate_coverage(matches)
+        summary = _generate_enhanced_summary(transcript, matches)
+        timeline_buf = self.timeline_generator.create_speaker_timeline(segments, matches)
+        timeline_bytes = timeline_buf.getvalue() if hasattr(timeline_buf, "getvalue") else b""
+
+        return TranscriptMetadata(
+            transcript=transcript,
+            segments=segments,
+            matches=matches,
+            coverage=coverage,
+            summary=summary,
+            timeline=timeline_bytes,
+        )
+


### PR DESCRIPTION
## Summary
- factor audio processing into new `PeerCheckPipeline` using asyncio
- replace inline processing logic to call the new pipeline

## Testing
- `python -m py_compile api/new_enhanced.py api/pipeline.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687cc6c712c8832f9e8c9df76d724499