### PR TITLE
Add abbreviation validation cleanup for PDF highlights

### DIFF
--- a/Acronyms1.csv
+++ b/Acronyms1.csv
@@ -83,7 +83,7 @@ ATI ,Automatic Test Indication / Insertion
 ATOMS ,Attitudes Toward Observations Maximizes Safety
 ATWS ,Anticipated Transients Without Scram
 ATWT ,Anticipated Transients Without Trip
-AUG ,Air Operated Valve Users’ Group
+AUG ,Air Operated Valve Usersï¿½ Group
 AUX ,Auxiliary
 AV ,Allowable Value
 AVT ,All Volatile Treatment
@@ -227,7 +227,7 @@ COC ,Chain Of Custody
 COE ,Centers of Excellence
 COLR ,Core Operating Limits Report
 conc ,concentration
-COTPC………………...,Control of Training Program Content
+COTPCï¿½ï¿½ï¿½ï¿½ï¿½ï¿½...,Control of Training Program Content
 CP ,Construction Permit
 CPA ,Containment Performance Analysis
 CPC ,Core Protection Calculators
@@ -323,7 +323,7 @@ DEP ,Drill and Exercise Performance
 DEPSG ,Double Ended Pump Suction Guillotine
 dept ,department
 DF ,Decontamination factor
-DFSS………………….,Dry Fuel Storage System
+DFSSï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½.,Dry Fuel Storage System
 DFBN ,Debris Filter Bottom Nozzle
 DFCS ,Digital Feedwater Control System
 DG; D/G ,Diesel Generator
@@ -400,7 +400,7 @@ EDEFSTS ,Emergency Diesel Engine Fuel Oil Storage & Transfer System
 EDELS ,Emergency Diesel Engine Lubrication System
 EDESS ,Emergency Diesel Engine Start System
 EDG ,Emergency Diesel Generator
-EDI’s ,Engineering Desk Instructions
+EDIï¿½s ,Engineering Desk Instructions
 EDMS ,Electronic Data Management System
 EDO ,Executive Director for Operations
 EDS ,Electrical Distribution System
@@ -651,7 +651,7 @@ ITIP ,Industry Technical Information Program
 ITP ,Individual Training Plan
 ITS ,Improved Technical Specifications
 ITS ,Incore Thermocouple System
-IT-TRG ,Instructor Training – Training Review Group
+IT-TRG ,Instructor Training ï¿½ Training Review Group
 IV ,Independent Verifier/Verification
 IV ,Intercept Valve
 JAR ,Job Authorization Request
@@ -662,7 +662,7 @@ JCO ,Justification for Continued Operation
 JFA ,Jumper Faucet Assembly
 JIC ,Joint Information Clearinghouse
 JITT ,Just-in-time Training
-JOG ,Joint Owners’ Group
+JOG ,Joint Ownersï¿½ Group
 JRB ,Job Review Board
 JRR ,John Redmond Reservoir
 JTA ,Job-Task-Analysis
@@ -900,6 +900,7 @@ NUREG ,Nuclear Utility Regulation
 NUSCO ,Northeast Utilities Service Co.
 NWRC ,No Work Required (Cancel)
 NWRO ,No Work Required (Non-Applicable OE)
+OPEN,open
 O&M ,Operational and Maintenance
 O&MR ,Operational and Maintenance Reminders
 O&P  ,Operational & Programmatic
@@ -996,7 +997,7 @@ PE ,Professional Engineer
 PEG ,Procurement Engineering Group
 PEO ,Plant Equipment Operator
 PEP ,Performance Enhancement Program
-PESS…………………....,Personnel Entrance Search Station (Main Security)
+PESSï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½....,Personnel Entrance Search Station (Main Security)
 PFCD ,Preliminary Fuel Cycle Design
 PFRT ,Positive Flux Rate Trip
 PFSS ,Post Fire Safe Shutdown
@@ -1187,7 +1188,9 @@ Rx ,Reactor
 S ,South
 S&L ,Sargent & Lundy
 S.W.I.M.  ,"Stop, Warn, Isolate and Minimize"
+SD,Shutdown
 "S/D, SD ",Shutdown
+SG,Steam Generator
 "S/G, SG ",Steam Generator
 S/U ,Start Up
 SACF ,Single Active Component Failure
@@ -1361,6 +1364,7 @@ SWS ,Service Water System
 swyd ,switchyard
 sync ,synchronize
 sys ,system
+TC,Thermocouple
 "T/C, TC ",Thermocouple
 T/G ,Turning Gear
 T/R ,transmitter/receiver
@@ -1368,11 +1372,11 @@ TA ,Tagging Authority
 TAB ,Training Advisory Board
 TAC ,Training Advisory Committee
 tach ,tachometer
-TADOT…………………  ,Trip Actuating Device Operational Test
+TADOTï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½  ,Trip Actuating Device Operational Test
 TAHL ,Temperature Alarm High Level
 TAR ,Travel Authorization Request
 Tauct ,Temperature (auctioneered)
-"Tavg, Tavg ",Temperature (average)
+Tavg,Temperature (average)
 T-brg ,Thrust Bearing
 TBS ,Turbine Bypass System
 TC; Tcold; Tcold ,Temperature (cold)
@@ -1424,7 +1428,7 @@ TSA ,Technical Service Authorization
 TSC ,Technical Support Center
 TSEO ,Technical Specification Equipment Outage
 TSI ,Turbine Supervisory Instrumentation
-TSO…………………...,Treatment System Operator
+TSOï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½...,Treatment System Operator
 TSO,Transmission System Operator
 TSP ,Technical Support
 TSR ,Technical Surveillance Requirements
@@ -1441,7 +1445,7 @@ UF ,Underfrequency
 UHF ,ultrahigh frequency
 UHS ,Ultimate Heat Sink
 UI ,Under Instruction
-UL ,Underwriters’ Laboratories Inc.
+UL ,Underwritersï¿½ Laboratories Inc.
 UNID ,Unique Equipment Identifier
 UPS ,Uninterruptible Power Supply
 URAL ,Underexcited Reactive Ampere Limit
@@ -1517,3 +1521,22 @@ xmtr ,transmitter
 XOVER ,Crossover
 ZERO ,Zero Environmental Release Options
 ZPA ,Zero Period Acceleration
+STROKE,stroke
+RELIEF,relief
+ATMOS,atmos
+ISO,iso
+AIR,air
+BLEED-OFF,bleed-off
+CLOSED,closed
+CIRCLE,circle
+CTRL/MAIN,ctrl/main
+INDICATING,indicating
+VERIFICATION,verification
+CONTINUING,continuing
+VALVE,valve
+WHITE,white
+ISOLATION,isolation
+SIMULTANEOUSLY,simultaneously
+OPPOSITE,opposite
+RESULTS,results
+CYCLE,cycle

--- a/Acronyms1.csv
+++ b/Acronyms1.csv
@@ -1540,3 +1540,4 @@ SIMULTANEOUSLY,simultaneously
 OPPOSITE,opposite
 RESULTS,results
 CYCLE,cycle
+VALVE.,valve

--- a/api/new_enhnaced.py
+++ b/api/new_enhnaced.py
@@ -2,6 +2,7 @@ import os
 import tempfile
 import uuid
 import time
+import logging
 from datetime import datetime, timedelta
 from django.conf import settings
 from django.http import HttpResponse, Http404
@@ -312,10 +313,20 @@ class DownloadProcessedDocumentView(GenericAPIView):
                     
                     # Create highlighted document based on file extension
                     file_ext = reference_doc.file_path.rsplit('.', 1)[-1].lower()
+                    use_transcript = (
+                        request.query_params.get("validate_abbreviations", "true")
+                        .lower()
+                        == "true"
+                    )
+                    logging.info(
+                        "validate_abbreviations=%s in DownloadProcessedDocumentView",
+                        use_transcript,
+                    )
                     if file_ext == 'pdf':
                         processed_s3_url = create_highlighted_pdf_document(
-                            reference_doc.file_path, 
-                            transcript
+                            reference_doc.file_path,
+                            transcript,
+                            require_transcript_match=use_transcript,
                         )
                     elif file_ext == 'docx':
                         from .new_utils import create_highlighted_docx_from_s3

--- a/api/new_utils.py
+++ b/api/new_utils.py
@@ -330,7 +330,7 @@ def _replace_validated_abbreviations(doc, validated_abbrs: dict) -> None:
         logging.info("No validated abbreviations to apply")
         return
 
-    dark_green = (0, 0.5, 0)
+    dark_green = (0.6, 1, 0.6)
     light_red = (1, 0.6, 0.6)
 
     def _is_light_red(color, target=light_red, tol=0.1):

--- a/api/new_utils.py
+++ b/api/new_utils.py
@@ -383,18 +383,24 @@ def generate_highlighted_pdf(doc_path, query_text, output_path):
     logging.info("Starting abbreviation cleanup pass")
     abbreviations = {}
     csv_path = os.path.join(settings.BASE_DIR, "Acronyms1.csv")
-    try:
-        with open(csv_path, newline="", encoding="utf-8") as csvfile:
-            reader = csv.reader(csvfile)
-            for row in reader:
-                if len(row) >= 2:
-                    abbr = row[0].strip()
-                    full = row[1].strip()
-                    if abbr and full:
-                        abbreviations[abbr] = full
-        logging.info(f"Loaded {len(abbreviations)} abbreviations from CSV")
-    except Exception as e:
-        logging.warning(f"Acronyms CSV could not be loaded: {e}")
+    for enc in ("utf-8", "cp1252"):
+        try:
+            with open(csv_path, newline="", encoding=enc) as csvfile:
+                reader = csv.reader(csvfile)
+                for row in reader:
+                    if len(row) >= 2:
+                        abbr = row[0].strip()
+                        full = row[1].strip()
+                        if abbr and full:
+                            abbreviations[abbr] = full
+            logging.info(
+                f"Loaded {len(abbreviations)} abbreviations from CSV using {enc}"
+            )
+            break
+        except Exception as e:
+            logging.warning(f"Failed to load acronyms CSV with {enc}: {e}")
+    if not abbreviations:
+        logging.warning("Acronyms CSV could not be loaded; skipping abbreviation cleanup")
 
     transcript_lower = query_text.lower()
 


### PR DESCRIPTION
## Summary
- Post-process red highlights in PDFs to validate known abbreviations via CSV lookup and transcript matching
- Replace validated red flags with dark-green highlights and detailed logging

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_b_6899c200060c832fba655e1fa712d445