### PR TITLE
Enhance diarization with speaker profiles and rerun support

### DIFF
--- a/api/management/commands/rerun_diarization.py
+++ b/api/management/commands/rerun_diarization.py
@@ -15,10 +15,10 @@ class Command(BaseCommand):
                 transcript = audio_file.transcription or {}
                 transcript_segments = transcript.get('segments', [])
                 transcript_words = transcript.get('words', [])
-                diarization_segments = diarization_from_audio(
+                diarization_result = diarization_from_audio(
                     audio_file.file_path, transcript_segments, transcript_words
                 )
-                audio_file.diarization = diarization_segments
+                audio_file.diarization = diarization_result
                 audio_file.save()
                 self.stdout.write(self.style.SUCCESS(f'Processed {audio_file.id}'))
             except Exception as e:

--- a/api/new_enhnaced.py
+++ b/api/new_enhnaced.py
@@ -30,7 +30,6 @@ from .new_serializers import (
 )
 from .speaker_utils import find_best_speaker_profile
 import requests
-from pyannote.audio import Pipeline
 import subprocess
 import threading
 

--- a/api/new_serializers.py
+++ b/api/new_serializers.py
@@ -164,6 +164,37 @@ class ErrorResponseSerializer(serializers.Serializer):
     details = serializers.DictField(read_only=True, required=False)
     timestamp = serializers.DateTimeField(read_only=True)
 
+
+class RunDiarizationSerializer(serializers.Serializer):
+    audio_id = serializers.UUIDField()
+
+
+class SpeakerProfileMappingEntrySerializer(serializers.Serializer):
+    label = serializers.CharField()
+    name = serializers.CharField()
+    profile_id = serializers.IntegerField(required=False, allow_null=True)
+
+    def validate_name(self, value: str) -> str:
+        if not value.strip():
+            raise serializers.ValidationError("Name cannot be blank.")
+        return value
+
+
+class SpeakerProfileMappingSerializer(serializers.Serializer):
+    audio_id = serializers.UUIDField()
+    speakers = SpeakerProfileMappingEntrySerializer(many=True)
+
+    def validate_speakers(self, value):
+        labels = set()
+        for entry in value:
+            label = entry.get('label')
+            if not label:
+                raise serializers.ValidationError("Each speaker entry must include a label.")
+            if label in labels:
+                raise serializers.ValidationError("Duplicate speaker labels are not allowed.")
+            labels.add(label)
+        return value
+
 class ReferenceDocumentSerializer(serializers.Serializer):
     """
     Serializer for the ReferenceDocument model.

--- a/api/new_utils.py
+++ b/api/new_utils.py
@@ -911,16 +911,18 @@ def diarization_from_audio(audio_url, transcript_segments, transcript_words=None
             if mean_vector is not None:
                 profile, match_score = find_best_speaker_profile(mean_vector, match_threshold)
 
-            if profile is None and mean_vector is not None:
+            if profile is None:
                 profile = SpeakerProfile.objects.filter(name=label).first()
                 if profile is None:
                     profile = SpeakerProfile.objects.create(name=label, embedding=mean_vector)
                     logger.debug("Created new speaker profile %s for label %s", profile.id, label)
-                else:
+                elif mean_vector is not None:
                     profile.embedding = mean_vector
                     profile.save(update_fields=["embedding", "updated_at"])
                     logger.debug("Updated existing speaker profile %s for label %s", profile.id, label)
-                match_score = 1.0
+
+                if match_score is None and mean_vector is not None:
+                    match_score = 1.0
 
             if profile and not profile.name:
                 profile.name = label

--- a/api/speaker_utils.py
+++ b/api/speaker_utils.py
@@ -20,6 +20,8 @@ def find_best_speaker_profile(
     best_profile = None
     best_score = 0.0
     for profile in SpeakerProfile.objects.all():
+        if not profile.embedding:
+            continue
         score = _cosine_similarity(embedding, profile.embedding)
         if score > best_score:
             best_score = score

--- a/api/speaker_utils.py
+++ b/api/speaker_utils.py
@@ -1,6 +1,6 @@
 import numpy as np
 from numpy.linalg import norm
-from typing import List, Dict, Optional
+from typing import List, Dict, Optional, Tuple
 
 from .models import SpeakerProfile
 
@@ -13,8 +13,10 @@ def _cosine_similarity(v1: List[float], v2: List[float]) -> float:
     return float(np.dot(a, b) / (norm(a) * norm(b)))
 
 
-def match_speaker_embedding(embedding: List[float], threshold: float = 0.8) -> Optional[SpeakerProfile]:
-    """Return the best matching speaker profile or None."""
+def find_best_speaker_profile(
+    embedding: List[float], threshold: float = 0.8
+) -> Tuple[Optional[SpeakerProfile], float]:
+    """Return the best matching speaker profile and cosine similarity score."""
     best_profile = None
     best_score = 0.0
     for profile in SpeakerProfile.objects.all():
@@ -23,8 +25,16 @@ def match_speaker_embedding(embedding: List[float], threshold: float = 0.8) -> O
             best_score = score
             best_profile = profile
     if best_profile and best_score >= threshold:
-        return best_profile
-    return None
+        return best_profile, best_score
+    return None, best_score
+
+
+def match_speaker_embedding(
+    embedding: List[float], threshold: float = 0.8
+) -> Optional[SpeakerProfile]:
+    """Return the best matching speaker profile or ``None``."""
+    profile, _ = find_best_speaker_profile(embedding, threshold)
+    return profile
 
 
 def assign_speaker_profiles(

--- a/api/tasks.py
+++ b/api/tasks.py
@@ -10,10 +10,10 @@ def process_missing_diarizations():
             transcript = audio_file.transcription or {}
             transcript_segments = transcript.get('segments', [])
             transcript_words = transcript.get('words', [])
-            diarization_segments = diarization_from_audio(
+            diarization_result = diarization_from_audio(
                 audio_file.file_path, transcript_segments, transcript_words
             )
-            audio_file.diarization = diarization_segments
+            audio_file.diarization = diarization_result
             audio_file.save()
         except Exception as e:
             # Optionally log the error

--- a/api/urls.py
+++ b/api/urls.py
@@ -63,15 +63,17 @@ urlpatterns = [
          name='upload_and_process'),
     
     # Download processed DOCX with highlighted text
-    path('download/<str:token>/<str:session_id>/', 
-         new_enhnaced.DownloadProcessedDocumentView.as_view(), 
+    path('download/<str:token>/<str:session_id>/',
+         new_enhnaced.DownloadProcessedDocumentView.as_view(),
          name='download_processed'),
-    
+
     path('documents/upload/<str:token>/', new_enhnaced.UploadReferenceDocumentView.as_view(), name='document-upload'),
+    path('diarization/rerun/<str:token>/', new_enhnaced.RunDiarizationView.as_view(), name='rerun-diarization'),
+    path('speakers/map/<str:token>/', new_enhnaced.SpeakerProfileMappingView.as_view(), name='speaker-profile-map'),
 
     # Get user's documents and audio files
-    path('documents/<str:token>/', 
-         new_enhnaced.GetUserDocumentsView.as_view(), 
+    path('documents/<str:token>/',
+         new_enhnaced.GetUserDocumentsView.as_view(),
          name='user_documents'),
     
     # Get specific processing session details


### PR DESCRIPTION
## Summary
- compute speaker embeddings during diarization, match them to stored profiles, and return structured speaker metadata
- expose APIs to rerun diarization and to map diarized speakers to named profiles, including supporting serializers and URL routes
- extend speaker utilities plus background jobs to work with the enhanced diarization payload

## Testing
- python -m compileall api

------
https://chatgpt.com/codex/tasks/task_b_68d4f8f62784832f9aecc282931fe090