### PR TITLE
Enhance diarization with speaker recognition

### DIFF
--- a/api/management/commands/rerun_diarization.py
+++ b/api/management/commands/rerun_diarization.py
@@ -1,6 +1,6 @@
 from django.core.management.base import BaseCommand
 from api.models import AudioFile
-from api.new_utils import diarization_from_audio
+from api.new_utils import diarization_from_audio, build_speaker_summary
 
 class Command(BaseCommand):
     help = 'Rerun diarization for AudioFiles with null diarization'
@@ -18,7 +18,10 @@ class Command(BaseCommand):
                 diarization_segments = diarization_from_audio(
                     audio_file.file_path, transcript_segments, transcript_words
                 )
-                audio_file.diarization = diarization_segments
+                audio_file.diarization = {
+                    'segments': diarization_segments,
+                    'speakers': build_speaker_summary(diarization_segments),
+                }
                 audio_file.save()
                 self.stdout.write(self.style.SUCCESS(f'Processed {audio_file.id}'))
             except Exception as e:

--- a/api/new_enhnaced.py
+++ b/api/new_enhnaced.py
@@ -4,6 +4,8 @@ import uuid
 import time
 import logging
 from datetime import datetime, timedelta
+
+import numpy as np
 from django.conf import settings
 from django.http import HttpResponse, Http404
 from django.utils import timezone
@@ -13,24 +15,39 @@ from rest_framework.response import Response
 from drf_yasg.utils import swagger_auto_schema
 from drf_yasg import openapi
 import traceback
-from .models import ReferenceDocument, AudioFile, ProcessingSession, UserProfile, AuditLog
+from .models import (
+    ReferenceDocument,
+    AudioFile,
+    ProcessingSession,
+    UserProfile,
+    AuditLog,
+    SpeakerProfile,
+)
 from .new_utils import (
-    extract_text_from_s3, transcribe_audio_from_s3, diarization_from_audio,  # <-- add diarization_from_audio
-    find_missing, upload_file_to_s3,
-    get_s3_key_from_url, s3_client, create_highlighted_pdf_document
+    extract_text_from_s3,
+    transcribe_audio_from_s3,
+    diarization_from_audio,
+    build_speaker_summary,
+    find_missing,
+    upload_file_to_s3,
+    get_s3_key_from_url,
+    s3_client,
+    create_highlighted_pdf_document,
 )
 from .authentication import token_verification
 from .new_serializers import (
-    UploadAndProcessSerializer, ProcessingResultSerializer,
-    DownloadRequestSerializer, UserDocumentsSerializer,
-    CleanupRequestSerializer, CleanupResponseSerializer,
-    ErrorResponseSerializer, ProcessingSessionDetailSerializer,
-    ReferenceDocumentSerializer
+    UploadAndProcessSerializer,
+    ProcessingResultSerializer,
+    DownloadRequestSerializer,
+    UserDocumentsSerializer,
+    CleanupRequestSerializer,
+    CleanupResponseSerializer,
+    ErrorResponseSerializer,
+    ProcessingSessionDetailSerializer,
+    ReferenceDocumentSerializer,
+    RunDiarizationSerializer,
+    SpeakerProfileMappingSerializer,
 )
-import requests
-from pyannote.audio import Pipeline
-import subprocess
-import threading
 
 class UploadAndProcessView(CreateAPIView):
     """
@@ -153,36 +170,25 @@ class UploadAndProcessView(CreateAPIView):
             audio_obj.save()
 
             # --- Speaker Diarization (using diarization_from_audio) ---
-            diarization_segments = []
+            diarization_payload = None
             diarization_error = None
-            # try:
-            #     diarization_segments = diarization_from_audio(audio_s3_url, transcript_segments, transcript_words)
-            # except Exception as diar_err:
-            #     diarization_error = str(diar_err)
-            #     print(f"Diarization error: {diarization_error}")
-            # audio_obj.diarization = diarization_segments if diarization_segments else None
-            # audio_obj.save()
-            # --- End Speaker Diarization ---
-            
-            # --- Speaker Diarization in Background Thread ---
-            def diarization_background(audio_file_id, audio_s3_url, transcript_segments, transcript_words):
-                try:
-                    diarization_segments = diarization_from_audio(audio_s3_url, transcript_segments, transcript_words)
-                    audio_file = AudioFile.objects.get(id=audio_file_id)
-                    audio_file.diarization = diarization_segments
-                    audio_file.save()
-                except Exception as diar_err:
-                    audio_file = AudioFile.objects.get(id=audio_file_id)
-                    audio_file.diarization = None
-                    audio_file.save()
-                    print(f"Diarization error (background): {str(diar_err)}")
-
-            diarization_thread = threading.Thread(
-                target=diarization_background,
-                args=(audio_obj.id, audio_s3_url, transcript_segments, transcript_words),
-                daemon=True
-            )
-            diarization_thread.start()
+            try:
+                diarization_segments = diarization_from_audio(
+                    audio_s3_url,
+                    transcript_segments,
+                    transcript_words,
+                )
+                diarization_payload = {
+                    'segments': diarization_segments,
+                    'speakers': build_speaker_summary(diarization_segments),
+                }
+                audio_obj.diarization = diarization_payload
+                audio_obj.save(update_fields=['transcription', 'diarization'])
+            except Exception as diar_err:
+                diarization_error = str(diar_err)
+                audio_obj.diarization = None
+                audio_obj.save(update_fields=['transcription', 'diarization'])
+                print(f"Diarization error: {diarization_error}")
             # --- End Speaker Diarization ---
             
             # Perform comparison analysis
@@ -226,7 +232,7 @@ class UploadAndProcessView(CreateAPIView):
                 'missing_content': missing_html,
                 'entire_document': entire_html,
                 'processing_time': round(processing_time, 2),
-                'diarization': diarization_segments if diarization_segments else None,
+                'diarization': diarization_payload,
                 'diarization_error': diarization_error
             }
 
@@ -253,6 +259,179 @@ class UploadAndProcessView(CreateAPIView):
             }
             
             return Response(error_data, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+
+class RunDiarizationView(CreateAPIView):
+    """API to rerun speaker diarization for a processed audio file."""
+
+    serializer_class = RunDiarizationSerializer
+
+    def create(self, request, token, *args, **kwargs):
+        auth_result = token_verification(token)
+        if auth_result['status'] != 200:
+            return Response({
+                'error': auth_result['error'],
+                'timestamp': timezone.now(),
+            }, status=status.HTTP_401_UNAUTHORIZED)
+
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        audio_id = serializer.validated_data['audio_id']
+
+        try:
+            audio_file = AudioFile.objects.get(id=audio_id)
+        except AudioFile.DoesNotExist:
+            return Response({
+                'error': 'Audio file not found',
+                'audio_id': str(audio_id),
+            }, status=status.HTTP_404_NOT_FOUND)
+
+        transcript = audio_file.transcription or {}
+        transcript_segments = transcript.get('segments', [])
+        transcript_words = transcript.get('words', [])
+
+        try:
+            diarization_segments = diarization_from_audio(
+                audio_file.file_path,
+                transcript_segments,
+                transcript_words,
+            )
+            diarization_payload = {
+                'segments': diarization_segments,
+                'speakers': build_speaker_summary(diarization_segments),
+            }
+            audio_file.diarization = diarization_payload
+            audio_file.save(update_fields=['diarization'])
+
+            return Response({
+                'audio_file_id': str(audio_file.id),
+                'diarization': diarization_payload,
+            }, status=status.HTTP_200_OK)
+        except Exception as exc:
+            audio_file.diarization = None
+            audio_file.save(update_fields=['diarization'])
+            return Response({
+                'error': f'Failed to run diarization: {str(exc)}',
+                'audio_file_id': str(audio_file.id),
+            }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+
+class SpeakerProfileMappingView(CreateAPIView):
+    """API to assign or update speaker profiles using diarization results."""
+
+    serializer_class = SpeakerProfileMappingSerializer
+
+    def create(self, request, token, *args, **kwargs):
+        auth_result = token_verification(token)
+        if auth_result['status'] != 200:
+            return Response({
+                'error': auth_result['error'],
+                'timestamp': timezone.now(),
+            }, status=status.HTTP_401_UNAUTHORIZED)
+
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        audio_id = serializer.validated_data['audio_id']
+        speaker_label = serializer.validated_data['speaker_label']
+        name = serializer.validated_data['name'].strip()
+        profile_id = serializer.validated_data.get('profile_id')
+
+        try:
+            audio_file = AudioFile.objects.get(id=audio_id)
+        except AudioFile.DoesNotExist:
+            return Response({
+                'error': 'Audio file not found',
+                'audio_id': str(audio_id),
+            }, status=status.HTTP_404_NOT_FOUND)
+
+        diarization_data = audio_file.diarization or {}
+        if isinstance(diarization_data, dict):
+            segments = diarization_data.get('segments', [])
+        else:
+            segments = diarization_data
+
+        if not segments:
+            return Response({
+                'error': 'No diarization data available for this audio file',
+                'audio_file_id': str(audio_file.id),
+            }, status=status.HTTP_400_BAD_REQUEST)
+
+        matched_segments = [
+            seg for seg in segments
+            if (seg.get('speaker_label') or seg.get('speaker')) == speaker_label
+        ]
+
+        if not matched_segments:
+            return Response({
+                'error': f'Speaker label {speaker_label} not found in diarization results',
+                'audio_file_id': str(audio_file.id),
+            }, status=status.HTTP_404_NOT_FOUND)
+
+        vectors = [
+            np.array(seg.get('speaker_vector'), dtype=float)
+            for seg in matched_segments if seg.get('speaker_vector')
+        ]
+
+        if not vectors:
+            return Response({
+                'error': 'Speaker embeddings are not available for the selected label',
+                'audio_file_id': str(audio_file.id),
+            }, status=status.HTTP_400_BAD_REQUEST)
+
+        mean_vector = np.mean(vectors, axis=0)
+        if mean_vector is None or np.isnan(mean_vector).any():
+            return Response({
+                'error': 'Failed to compute a valid speaker embedding for the selected label',
+                'audio_file_id': str(audio_file.id),
+            }, status=status.HTTP_400_BAD_REQUEST)
+
+        try:
+            if profile_id:
+                profile = SpeakerProfile.objects.get(id=profile_id)
+                profile.embedding = mean_vector.tolist()
+                profile.name = name or profile.name
+                profile.save()
+            else:
+                profile = SpeakerProfile.objects.filter(name__iexact=name).first()
+                if profile:
+                    profile.embedding = mean_vector.tolist()
+                    profile.name = name
+                    profile.save()
+                else:
+                    profile = SpeakerProfile.objects.create(
+                        name=name or speaker_label,
+                        embedding=mean_vector.tolist(),
+                    )
+        except SpeakerProfile.DoesNotExist:
+            return Response({
+                'error': 'Specified speaker profile does not exist',
+                'profile_id': profile_id,
+            }, status=status.HTTP_404_NOT_FOUND)
+
+        updated_segments = []
+        for seg in segments:
+            seg_label = seg.get('speaker_label') or seg.get('speaker')
+            if seg_label == speaker_label:
+                seg['speaker'] = profile.name or speaker_label
+                seg['speaker_profile_id'] = profile.id
+            updated_segments.append(seg)
+
+        diarization_payload = {
+            'segments': updated_segments,
+            'speakers': build_speaker_summary(updated_segments),
+        }
+        audio_file.diarization = diarization_payload
+        audio_file.save(update_fields=['diarization'])
+
+        return Response({
+            'audio_file_id': str(audio_file.id),
+            'speaker_profile': {
+                'id': profile.id,
+                'name': profile.name,
+            },
+            'diarization': diarization_payload,
+        }, status=status.HTTP_200_OK)
 
 class DownloadProcessedDocumentView(GenericAPIView):
     """

--- a/api/new_serializers.py
+++ b/api/new_serializers.py
@@ -200,6 +200,17 @@ class ReferenceDocumentSerializer(serializers.Serializer):
     #         'created_at',
     #         'extracted_text' # Included for response, but not for input
     #     ]
+
+
+class RunDiarizationSerializer(serializers.Serializer):
+    audio_id = serializers.UUIDField()
+
+
+class SpeakerProfileMappingSerializer(serializers.Serializer):
+    audio_id = serializers.UUIDField()
+    speaker_label = serializers.CharField(max_length=50)
+    name = serializers.CharField(max_length=255)
+    profile_id = serializers.IntegerField(required=False)
     #     # These fields are set by the server, not provided by the client on upload.
     #     read_only_fields = [
     #         'id', 

--- a/api/new_utils.py
+++ b/api/new_utils.py
@@ -4,7 +4,12 @@ import string
 import tempfile
 import csv
 import logging
+import threading
+from typing import Dict, List, Optional
+
 import boto3
+import numpy as np
+from django.conf import settings as django_settings
 from peercheck import settings
 from pdf2docx import Converter
 import whisper
@@ -24,8 +29,51 @@ from docx.shared import RGBColor
 import fitz  # PyMuPDF
 from docx2pdf import convert
 
+from pyannote.audio import Pipeline, Inference, Model
+from pyannote.core import Segment
+
+from .models import SpeakerProfile
+from .speaker_utils import match_speaker_embedding
+
 # Load Whisper model once
 model = whisper.load_model(getattr(settings, 'WHISPER_MODEL', 'small.en'))
+
+_DIARIZATION_PIPELINE: Optional[Pipeline] = None
+_EMBEDDING_INFERENCE: Optional[Inference] = None
+_MODEL_LOCK = threading.Lock()
+
+
+def _get_hf_token() -> Optional[str]:
+    """Return the Hugging Face token if available."""
+    token = getattr(settings, "HF_TOKEN", None) or getattr(django_settings, "HF_TOKEN", None)
+    return token
+
+
+def _get_diarization_pipeline() -> Pipeline:
+    """Lazily initialise the diarization pipeline."""
+    global _DIARIZATION_PIPELINE
+    if _DIARIZATION_PIPELINE is None:
+        with _MODEL_LOCK:
+            if _DIARIZATION_PIPELINE is None:
+                _DIARIZATION_PIPELINE = Pipeline.from_pretrained(
+                    "pyannote/speaker-diarization-3.1",
+                    use_auth_token=_get_hf_token(),
+                )
+    return _DIARIZATION_PIPELINE
+
+
+def _get_embedding_inference() -> Inference:
+    """Lazily initialise the speaker embedding inference model."""
+    global _EMBEDDING_INFERENCE
+    if _EMBEDDING_INFERENCE is None:
+        with _MODEL_LOCK:
+            if _EMBEDDING_INFERENCE is None:
+                embedding_model = Model.from_pretrained(
+                    "pyannote/embedding",
+                    use_auth_token=_get_hf_token(),
+                )
+                _EMBEDDING_INFERENCE = Inference(embedding_model, window="whole")
+    return _EMBEDDING_INFERENCE
 
 # Initialize S3 client
 s3_client = boto3.client(
@@ -631,19 +679,20 @@ def create_highlighted_docx_from_s3(text_s3_url, transcript, high_threshold=0.6,
             os.unlink(output_path)
 
 def diarization_from_audio(audio_url, transcript_segments, transcript_words=None):
-    import requests, tempfile, os, subprocess
-    from pyannote.audio import Pipeline
-    from django.conf import settings
-    
-    # Download audio
+    import requests
+    import subprocess
+
+    threshold = getattr(settings, "SPEAKER_MATCH_THRESHOLD", 0.8)
+
+    # Download audio locally for processing
     local_audio_path = os.path.join(tempfile.gettempdir(), f"diar_{os.path.basename(audio_url)}")
     with requests.get(audio_url, stream=True) as r:
         r.raise_for_status()
         with open(local_audio_path, 'wb') as f:
             for chunk in r.iter_content(chunk_size=8192):
                 f.write(chunk)
-    
-    # Convert to wav if needed
+
+    # Convert to mono 16k wav for consistency
     wav_path = local_audio_path
     if not local_audio_path.lower().endswith('.wav'):
         wav_path = local_audio_path.rsplit('.', 1)[0] + '.wav'
@@ -653,13 +702,9 @@ def diarization_from_audio(audio_url, transcript_segments, transcript_words=None
         ]
         subprocess.run(command, check=True)
         os.unlink(local_audio_path)
-    
-    # Run diarization
-    pipeline = Pipeline.from_pretrained(
-        "pyannote/speaker-diarization-3.1",
-        use_auth_token=settings.HF_TOKEN
-    )
-    diarization = pipeline(wav_path)
+
+    diarization = _get_diarization_pipeline()(wav_path)
+    embedding_inference = _get_embedding_inference()
     
     def get_segment_text_from_words(words, seg_start, seg_end, overlap_threshold=0.1):
         """
@@ -735,22 +780,31 @@ def diarization_from_audio(audio_url, transcript_segments, transcript_words=None
         return " ".join(t['text'] for t in segment_texts if t['text'])
     
     def merge_consecutive_same_speaker_segments(segments, max_gap=1.0):
-        """
-        Merge consecutive segments from the same speaker if they're close together.
-        """
+        """Merge consecutive segments from the same speaker if they're close together."""
         if not segments:
             return segments
-        
+
         merged = []
-        current_segment = segments[0].copy()
-        
+
+        def _init_segment(segment):
+            seg = segment.copy()
+            vectors = []
+            vec = seg.get("speaker_vector")
+            if vec:
+                vectors.append(vec)
+            seg["_vectors"] = vectors
+            return seg
+
+        current_segment = _init_segment(segments[0])
+
         for i in range(1, len(segments)):
-            next_segment = segments[i]
-            
+            next_segment = _init_segment(segments[i])
+
             # Check if same speaker and segments are close
-            if (current_segment['speaker'] == next_segment['speaker'] and 
-                next_segment['start'] - current_segment['end'] <= max_gap):
-                
+            if (
+                current_segment['speaker'] == next_segment['speaker'] and
+                next_segment['start'] - current_segment['end'] <= max_gap
+            ):
                 # Merge segments
                 current_segment['end'] = next_segment['end']
                 if next_segment['text'].strip():
@@ -758,51 +812,139 @@ def diarization_from_audio(audio_url, transcript_segments, transcript_words=None
                         current_segment['text'] += " " + next_segment['text']
                     else:
                         current_segment['text'] = next_segment['text']
+                current_segment["_vectors"].extend(next_segment.get("_vectors", []))
+                if next_segment.get("duration"):
+                    current_segment['duration'] = round(
+                        current_segment.get('end', next_segment['end']) - current_segment.get('start', next_segment['start']), 2
+                    )
             else:
-                # Different speaker or gap too large, save current and start new
                 merged.append(current_segment)
-                current_segment = next_segment.copy()
-        
-        # Add the last segment
+                current_segment = next_segment
+
         merged.append(current_segment)
+
+        # Compute averaged vectors and clean helper keys
+        for seg in merged:
+            vectors = seg.pop("_vectors", [])
+            if vectors:
+                try:
+                    seg['speaker_vector'] = (
+                        np.mean(np.array(vectors, dtype=float), axis=0).tolist()
+                    )
+                except Exception:
+                    seg['speaker_vector'] = vectors[0]
+
         return merged
     
     # Process diarization results
     diarization_segments = []
-    
+    label_map: Dict[str, str] = {}
+    label_index = 0
+
     for turn, _, speaker in diarization.itertracks(yield_label=True):
         seg_start = float(turn.start)
         seg_end = float(turn.end)
-        
+
         # Extract text using the appropriate method
         if transcript_words:
             segment_text = get_segment_text_from_words(transcript_words, seg_start, seg_end)
         else:
             segment_text = get_segment_text_from_segments(transcript_segments, seg_start, seg_end)
-        
+
         # Only add segments with actual content or significant duration
         if segment_text.strip() or (seg_end - seg_start) > 0.5:
+            if speaker not in label_map:
+                label_map[speaker] = f"SPEAKER_{label_index}"
+                label_index += 1
+
+            segment = Segment(seg_start, seg_end)
+            vector = embedding_inference.crop(wav_path, segment)
+            vector_list = vector.tolist() if vector is not None else None
+
             diarization_segments.append({
-                "speaker": speaker,
+                "speaker": label_map[speaker],
+                "speaker_label": label_map[speaker],
                 "start": seg_start,
                 "end": seg_end,
                 "text": segment_text.strip(),
-                "duration": round(seg_end - seg_start, 2)
+                "duration": round(seg_end - seg_start, 2),
+                "speaker_vector": vector_list,
+                "speaker_profile_id": None,
             })
-    
+
     # Merge consecutive segments from the same speaker
     diarization_segments = merge_consecutive_same_speaker_segments(diarization_segments)
-    
+
     # Filter out very short segments with no text
     diarization_segments = [
         seg for seg in diarization_segments 
         if seg['text'].strip() or seg['duration'] > 1.0
     ]
     
+    # Attempt to match diarized speakers with stored profiles
+    label_vectors: Dict[str, List[List[float]]] = {}
+    for segment in diarization_segments:
+        label = segment.get("speaker_label") or segment.get("speaker")
+        vec = segment.get("speaker_vector")
+        if label and vec:
+            label_vectors.setdefault(label, []).append(vec)
+
+    matched_profiles: Dict[str, SpeakerProfile] = {}
+    for label, vectors in label_vectors.items():
+        try:
+            mean_vec = np.mean(np.array(vectors, dtype=float), axis=0)
+        except Exception:
+            continue
+        if mean_vec is None:
+            continue
+        profile = match_speaker_embedding(mean_vec.tolist(), threshold=threshold)
+        if profile:
+            matched_profiles[label] = profile
+
+    for segment in diarization_segments:
+        label = segment.get("speaker_label") or segment.get("speaker")
+        profile = matched_profiles.get(label)
+        if profile:
+            segment["speaker"] = profile.name or label
+            segment["speaker_profile_id"] = profile.id
+
     # Clean up
-    os.unlink(wav_path)
-    
+    if os.path.exists(wav_path):
+        os.unlink(wav_path)
+
     return diarization_segments
+
+
+# Diarization helpers
+
+def build_speaker_summary(segments: Optional[List[Dict]]) -> List[Dict]:
+    summary: Dict[str, Dict] = {}
+    for seg in segments or []:
+        label = seg.get('speaker_label') or seg.get('speaker')
+        if not label:
+            continue
+        entry = summary.setdefault(
+            label,
+            {
+                'speaker_label': label,
+                'speaker_name': None,
+                'speaker_profile_id': None,
+                'segment_count': 0,
+                'total_duration': 0.0,
+            },
+        )
+        entry['segment_count'] += 1
+        entry['total_duration'] += float(seg.get('duration') or 0.0)
+        if seg.get('speaker_profile_id'):
+            entry['speaker_profile_id'] = seg['speaker_profile_id']
+            entry['speaker_name'] = seg.get('speaker')
+        elif entry['speaker_name'] is None:
+            entry['speaker_name'] = seg.get('speaker') if seg.get('speaker_profile_id') else None
+
+    for entry in summary.values():
+        entry['total_duration'] = round(entry['total_duration'], 2)
+
+    return list(summary.values())
 
 
 # --- CORE THREE-COLOR HIGHLIGHTING LOGIC ---

--- a/api/tasks.py
+++ b/api/tasks.py
@@ -1,6 +1,6 @@
 from celery import shared_task
 from api.models import AudioFile
-from api.new_utils import diarization_from_audio
+from api.new_utils import diarization_from_audio, build_speaker_summary
 
 @shared_task
 def process_missing_diarizations():
@@ -13,7 +13,10 @@ def process_missing_diarizations():
             diarization_segments = diarization_from_audio(
                 audio_file.file_path, transcript_segments, transcript_words
             )
-            audio_file.diarization = diarization_segments
+            audio_file.diarization = {
+                'segments': diarization_segments,
+                'speakers': build_speaker_summary(diarization_segments),
+            }
             audio_file.save()
         except Exception as e:
             # Optionally log the error

--- a/api/urls.py
+++ b/api/urls.py
@@ -63,20 +63,28 @@ urlpatterns = [
          name='upload_and_process'),
     
     # Download processed DOCX with highlighted text
-    path('download/<str:token>/<str:session_id>/', 
-         new_enhnaced.DownloadProcessedDocumentView.as_view(), 
+    path('download/<str:token>/<str:session_id>/',
+         new_enhnaced.DownloadProcessedDocumentView.as_view(),
          name='download_processed'),
-    
+
     path('documents/upload/<str:token>/', new_enhnaced.UploadReferenceDocumentView.as_view(), name='document-upload'),
 
     # Get user's documents and audio files
-    path('documents/<str:token>/', 
-         new_enhnaced.GetUserDocumentsView.as_view(), 
+    path('documents/<str:token>/',
+         new_enhnaced.GetUserDocumentsView.as_view(),
          name='user_documents'),
-    
+
+    path('audio/<str:token>/diarization/run/',
+         new_enhnaced.RunDiarizationView.as_view(),
+         name='run-diarization'),
+
+    path('audio/<str:token>/diarization/map/',
+         new_enhnaced.SpeakerProfileMappingView.as_view(),
+         name='speaker-profile-map'),
+
     # Get specific processing session details
-    path('session/<str:token>/<uuid:session_id>/', 
-         new_enhnaced.GetProcessingSessionView.as_view(), 
+    path('session/<str:token>/<uuid:session_id>/',
+         new_enhnaced.GetProcessingSessionView.as_view(),
          name='get_session'),
     
     # Admin cleanup of expired sessions


### PR DESCRIPTION
## Summary
- extend diarization utilities to generate speaker embeddings, map to stored profiles, and provide summary metadata
- update upload processing to persist enriched diarization payloads and expose rerun plus speaker-mapping APIs
- refresh management command, Celery task, and routing to use the enhanced diarization outputs

## Testing
- python manage.py check *(fails: Django not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d540f1abf4832fb3262d62578bc11e