### PR TITLE
Enhance processed document highlights with speaker summary

### DIFF
--- a/api/new_enhnaced.py
+++ b/api/new_enhnaced.py
@@ -529,6 +529,7 @@ class DownloadProcessedDocumentView(GenericAPIView):
                             reference_doc.file_path,
                             transcript_result,
                             require_transcript_match=use_transcript,
+                            diarization_data=audio_file.diarization,
                         )
                     elif file_ext == 'docx':
                         from .new_utils import create_highlighted_docx_from_s3

--- a/api/new_enhnaced.py
+++ b/api/new_enhnaced.py
@@ -504,9 +504,10 @@ class DownloadProcessedDocumentView(GenericAPIView):
                 print("Creating new processed document...")
                 try:
                     # Create highlighted DOCX and upload to S3
-                    transcript = audio_file.transcription.get('text', '') if audio_file.transcription else ''
-                    
-                    if not transcript:
+                    transcript_result = audio_file.transcription or {}
+                    transcript_text = transcript_result.get('text', '')
+
+                    if not transcript_text:
                         return Response({
                             'error': 'No transcript available for processing',
                             'timestamp': timezone.now().isoformat()
@@ -526,14 +527,14 @@ class DownloadProcessedDocumentView(GenericAPIView):
                     if file_ext == 'pdf':
                         processed_s3_url = create_highlighted_pdf_document(
                             reference_doc.file_path,
-                            transcript,
+                            transcript_result,
                             require_transcript_match=use_transcript,
                         )
                     elif file_ext == 'docx':
                         from .new_utils import create_highlighted_docx_from_s3
                         processed_s3_url = create_highlighted_docx_from_s3(
                             reference_doc.file_path,
-                            transcript
+                            transcript_text
                         )
                     else:
                         return Response({


### PR DESCRIPTION
## Summary
- pass the complete transcription payload into the processed document generator and continue supporting DOCX highlighting
- expand PDF highlighting to differentiate mismatched versus unspoken content and add a per-page spoken-content summary box with timestamps
- update DOCX highlighting to use dedicated colors for match, mismatch, and unspoken passages

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d612d06134832fb2da3b70cace0664